### PR TITLE
Use semver compliant version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EnOcean
-version=0.1.0.0
+version=0.1.0-0
 author=Takashi Sunohara
 maintainer=Takashi Sunohara
 sentence=ESP3 Parser using the EnOcean Shield (TCM410J) by SiMICS. The operation have been confirmed with Arduino Uno R3.


### PR DESCRIPTION
Non-semver compliant `version` value causes the Arduino IDE to display warnings:
```
Invalid version found: 0.1.0.0
```
This warning can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

References:
- https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format
- https://semver.org/